### PR TITLE
feat: 소유 차량 저장

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { OwnCarsModule } from './own-cars/own-cars.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ConfigModule } from '@nestjs/config';
     }),
     UsersModule,
     AuthModule,
+    OwnCarsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/own-cars/constants/own-cars.constants.ts
+++ b/src/own-cars/constants/own-cars.constants.ts
@@ -1,0 +1,3 @@
+export const OWN_CAR_ERROR_MESSAGE = {
+  NOT_EXIST_USER: '해당 유저가 존재하지 않습니다',
+};

--- a/src/own-cars/dto/create-own-car.dto.ts
+++ b/src/own-cars/dto/create-own-car.dto.ts
@@ -1,1 +1,6 @@
-export class CreateOwnCarDto {}
+import { IsString } from 'class-validator';
+
+export class CreateOwnCarDto {
+  @IsString()
+  trim_id: string;
+}

--- a/src/own-cars/dto/create-own-car.dto.ts
+++ b/src/own-cars/dto/create-own-car.dto.ts
@@ -1,0 +1,1 @@
+export class CreateOwnCarDto {}

--- a/src/own-cars/entities/own-car.entity.ts
+++ b/src/own-cars/entities/own-car.entity.ts
@@ -1,1 +1,26 @@
-export class OwnCar {}
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { User } from '../../users/entities/user.entity';
+
+@Entity()
+export class OwnCar {
+  @PrimaryGeneratedColumn()
+  OWN_CAR_ID: number;
+
+  @ManyToOne(() => User, (user) => user.ownCars, { eager: false })
+  @JoinColumn({ name: 'USER_ID' })
+  user: User;
+
+  @Column()
+  OWN_CAR_TRIM_ID: string;
+
+  @CreateDateColumn()
+  OWN_CAR_CREATED_AT: Date;
+}

--- a/src/own-cars/entities/own-car.entity.ts
+++ b/src/own-cars/entities/own-car.entity.ts
@@ -1,0 +1,1 @@
+export class OwnCar {}

--- a/src/own-cars/own-cars.controller.ts
+++ b/src/own-cars/own-cars.controller.ts
@@ -1,4 +1,17 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { GetUser } from '../common/decorator/get-user.decorator';
+import { CreateOwnCarDto } from './dto/create-own-car.dto';
+import { OwnCarsService } from './own-cars.service';
 
 @Controller('own-cars')
-export class OwnCarsController {}
+export class OwnCarsController {
+  constructor(private readonly ownCarsService: OwnCarsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  async create(@Body() createOwnCarDto: CreateOwnCarDto, @GetUser() user) {
+    return await this.ownCarsService.create(createOwnCarDto, user.user_id);
+  }
+}

--- a/src/own-cars/own-cars.controller.ts
+++ b/src/own-cars/own-cars.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('own-cars')
+export class OwnCarsController {}

--- a/src/own-cars/own-cars.module.ts
+++ b/src/own-cars/own-cars.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { OwnCar } from './entities/own-car.entity';
 import { OwnCarsService } from './own-cars.service';
 import { OwnCarsController } from './own-cars.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([OwnCar]), UsersModule],
   providers: [OwnCarsService],
   controllers: [OwnCarsController],
 })

--- a/src/own-cars/own-cars.module.ts
+++ b/src/own-cars/own-cars.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OwnCarsService } from './own-cars.service';
+import { OwnCarsController } from './own-cars.controller';
+
+@Module({
+  providers: [OwnCarsService],
+  controllers: [OwnCarsController],
+})
+export class OwnCarsModule {}

--- a/src/own-cars/own-cars.service.ts
+++ b/src/own-cars/own-cars.service.ts
@@ -1,4 +1,34 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreateOwnCarDto } from './dto/create-own-car.dto';
+import { OwnCar } from './entities/own-car.entity';
+import { UsersService } from '../users/users.service';
+import { OWN_CAR_ERROR_MESSAGE } from './constants/own-cars.constants';
 
 @Injectable()
-export class OwnCarsService {}
+export class OwnCarsService {
+  constructor(
+    @InjectRepository(OwnCar) private ownCarsRepository: Repository<OwnCar>,
+    private usersService: UsersService,
+  ) {}
+
+  async create(
+    createOwnCarDto: CreateOwnCarDto,
+    user_id: string,
+  ): Promise<OwnCar> {
+    const user = await this.usersService.findOne(user_id);
+
+    if (!user) {
+      throw new BadRequestException(OWN_CAR_ERROR_MESSAGE.NOT_EXIST_USER);
+    }
+
+    return await this.ownCarsRepository.save(
+      this.ownCarsRepository.create({
+        OWN_CAR_TRIM_ID: createOwnCarDto.trim_id,
+        user,
+      }),
+    );
+  }
+}

--- a/src/own-cars/own-cars.service.ts
+++ b/src/own-cars/own-cars.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class OwnCarsService {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -3,12 +3,14 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { InternalServerErrorException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 import { USER_CONSTANTS } from '../constants/users.constants';
+import { OwnCar } from '../../own-cars/entities/own-car.entity';
 
 @Entity()
 export class User {
@@ -23,6 +25,9 @@ export class User {
 
   @CreateDateColumn()
   USER_CREATED_AT: Date;
+
+  @OneToMany(() => OwnCar, (ownCar) => ownCar.OWN_CAR_ID, { eager: false })
+  ownCars: OwnCar[];
 
   @BeforeInsert()
   async hashPassword(): Promise<void> {


### PR DESCRIPTION
## 개요
소유 차량 저장, own_car 테이블 생성

## 세부내용
- user와 own_car 테이블에 대한 관계 설정(1:N)
- trim_id와 user_id를 사용하여 own_car 테이블에 소유 차량 정보를 저장
- 임시로 POST 요청을 통해 소유 차량 정보를 저장하도록 `/own-cars` 엔드포인트 추가

## 관련 이슈
#13 
