### PR TITLE
feat: 타이어 정보 저장

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^0.0.3",
         "@nestjs/common": "^8.0.0",
         "@nestjs/config": "^1.1.2",
         "@nestjs/core": "^8.0.0",
@@ -1492,6 +1493,27 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nestjs/axios": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.3.tgz",
+      "integrity": "sha512-Cc+D2S2uesthRpalmZEPdm5wF2N9ji4l9Wsb2vFaug/CVWg2BoegHm0L1jzFUL+6kS+mXWSFvwXJmofv+7bajw==",
+      "dependencies": {
+        "axios": "0.23.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@nestjs/axios/node_modules/axios": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -11841,6 +11863,24 @@
             "minizlib": "^2.1.1",
             "mkdirp": "^1.0.3",
             "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@nestjs/axios": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.3.tgz",
+      "integrity": "sha512-Cc+D2S2uesthRpalmZEPdm5wF2N9ji4l9Wsb2vFaug/CVWg2BoegHm0L1jzFUL+6kS+mXWSFvwXJmofv+7bajw==",
+      "requires": {
+        "axios": "0.23.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+          "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^0.0.3",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^1.1.2",
     "@nestjs/core": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,14 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { Connection } from 'typeorm';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
-import { ConfigModule } from '@nestjs/config';
 import { OwnCarsModule } from './own-cars/own-cars.module';
 import { TiresModule } from './tires/tires.module';
-import { Connection } from 'typeorm';
 
 @Module({
   imports: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { OwnCarsModule } from './own-cars/own-cars.module';
 import { TiresModule } from './tires/tires.module';
+import { Connection } from 'typeorm';
 
 @Module({
   imports: [
@@ -29,4 +30,6 @@ import { TiresModule } from './tires/tires.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(private connection: Connection) {}
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { OwnCarsModule } from './own-cars/own-cars.module';
+import { TiresModule } from './tires/tires.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { OwnCarsModule } from './own-cars/own-cars.module';
     UsersModule,
     AuthModule,
     OwnCarsModule,
+    TiresModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/own-cars/dto/create-own-car.dto.ts
+++ b/src/own-cars/dto/create-own-car.dto.ts
@@ -1,6 +1,6 @@
-import { IsString } from 'class-validator';
+import { IsNumber } from 'class-validator';
 
 export class CreateOwnCarDto {
-  @IsString()
-  trim_id: string;
+  @IsNumber()
+  trim_id: number;
 }

--- a/src/own-cars/entities/own-car.entity.ts
+++ b/src/own-cars/entities/own-car.entity.ts
@@ -19,7 +19,7 @@ export class OwnCar {
   user: User;
 
   @Column()
-  OWN_CAR_TRIM_ID: string;
+  OWN_CAR_TRIM_ID: number;
 
   @CreateDateColumn()
   OWN_CAR_CREATED_AT: Date;

--- a/src/own-cars/own-cars.module.ts
+++ b/src/own-cars/own-cars.module.ts
@@ -10,5 +10,6 @@ import { UsersModule } from '../users/users.module';
   imports: [TypeOrmModule.forFeature([OwnCar]), UsersModule],
   providers: [OwnCarsService],
   controllers: [OwnCarsController],
+  exports: [OwnCarsService],
 })
 export class OwnCarsModule {}

--- a/src/tires/constants/tire.constants.ts
+++ b/src/tires/constants/tire.constants.ts
@@ -5,3 +5,7 @@ export const TIRE_CONSTANTS = {
   TIRE_SPEC_SPLIT_REGEX: /[\/R]/g,
   CAR_SPEC_API_URL: 'https://dev.mycar.cardoc.co.kr/v1/trim/',
 };
+
+export const TIRE_ERROR_MSG = {
+  INVALID_INPUT_DATA: '입력 정보가 잘못되었습니다',
+};

--- a/src/tires/constants/tire.constants.ts
+++ b/src/tires/constants/tire.constants.ts
@@ -1,0 +1,7 @@
+export const TIRE_CONSTANTS = {
+  VALID_TIRE_STATUS: 'success',
+  INVALID_TIRE_STATUS: 'error',
+  TIRE_FORMAT_REGEX: /^[0-9]{3}\/[0-9]{2}R[0-9]{2}/g,
+  TIRE_SPEC_SPLIT_REGEX: /[\/R]/g,
+  CAR_SPEC_API_URL: 'https://dev.mycar.cardoc.co.kr/v1/trim/',
+};

--- a/src/tires/dto/create-tire.dto.ts
+++ b/src/tires/dto/create-tire.dto.ts
@@ -1,0 +1,14 @@
+import { IsNumber, IsString } from 'class-validator';
+
+export class CreateTireDto {
+  constructor({ user_id, trim_id }) {
+    this.user_id = user_id;
+    this.trim_id = trim_id;
+  }
+
+  @IsString()
+  user_id: string;
+
+  @IsNumber()
+  trim_id: number;
+}

--- a/src/tires/entities/tire.entity.ts
+++ b/src/tires/entities/tire.entity.ts
@@ -1,4 +1,32 @@
-import { Entity } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { OwnCar } from '../../own-cars/entities/own-car.entity';
 
 @Entity()
-export class Tire {}
+export class Tire {
+  @PrimaryGeneratedColumn()
+  TIRE_ID: number;
+
+  @Column()
+  TIRE_WIDTH: number;
+
+  @Column()
+  TIRE_ASPECT_RATIO: number;
+
+  @Column()
+  TIRE_WHEEL_SIZE: number;
+
+  @CreateDateColumn()
+  TIRE_CREATED_AT: Date;
+
+  @OneToOne(() => OwnCar)
+  @JoinColumn({ name: 'OWN_CAR_ID' })
+  ownCar: OwnCar;
+}

--- a/src/tires/entities/tire.entity.ts
+++ b/src/tires/entities/tire.entity.ts
@@ -1,0 +1,4 @@
+import { Entity } from 'typeorm';
+
+@Entity()
+export class Tire {}

--- a/src/tires/entities/tire.entity.ts
+++ b/src/tires/entities/tire.entity.ts
@@ -15,13 +15,22 @@ export class Tire {
   TIRE_ID: number;
 
   @Column()
-  TIRE_WIDTH: number;
+  TIRE_FRONT_WIDTH: number;
 
   @Column()
-  TIRE_ASPECT_RATIO: number;
+  TIRE_FRONT_ASPECT_RATIO: number;
 
   @Column()
-  TIRE_WHEEL_SIZE: number;
+  TIRE_FRONT_WHEEL_SIZE: number;
+
+  @Column()
+  TIRE_REAR_WIDTH: number;
+
+  @Column()
+  TIRE_REAR_ASPECT_RATIO: number;
+
+  @Column()
+  TIRE_REAR_WHEEL_SIZE: number;
 
   @CreateDateColumn()
   TIRE_CREATED_AT: Date;

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -17,7 +17,9 @@ export class TiresController {
 
   @UseGuards(JwtAuthGuard)
   @Post()
-  async create(@Body() body): Promise<{ createdTireCount: number }> {
+  async create(
+    @Body() body,
+  ): Promise<{ createdTireCount: number; result: any }> {
     this.checkArrayType(body);
 
     const createdTireList = [];
@@ -29,7 +31,10 @@ export class TiresController {
     }
 
     return {
-      createdTireCount: createdTireList.length,
+      createdTireCount: createdTireList.filter(
+        (item) => item.status === 'success',
+      ).length,
+      result: createdTireList,
     };
   }
 

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+
+import { TiresService } from './tires.service';
+
+@Controller('tires')
+export class TiresController {
+  constructor(private readonly tiresService: TiresService) {}
+}

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -5,9 +5,9 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
-import { validate } from 'class-validator';
 
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TIRE_CONSTANTS, TIRE_ERROR_MSG } from './constants/tire.constants';
 import { CreateTireDto } from './dto/create-tire.dto';
 import { TiresService } from './tires.service';
 
@@ -25,14 +25,12 @@ export class TiresController {
     const createdTireList = [];
     for (const elem of body) {
       const createTireDto = new CreateTireDto({ ...elem });
-      await this.validateCreateTireDto(createTireDto);
-
       createdTireList.push(await this.tiresService.create(createTireDto));
     }
 
     return {
       createdTireCount: createdTireList.filter(
-        (item) => item.status === 'success',
+        (item) => item.status === TIRE_CONSTANTS.VALID_TIRE_STATUS,
       ).length,
       result: createdTireList,
     };
@@ -40,16 +38,7 @@ export class TiresController {
 
   private checkArrayType(body): void {
     if (!(body instanceof Array)) {
-      throw new BadRequestException('입력 정보가 잘못되었습니다');
-    }
-  }
-
-  private async validateCreateTireDto(
-    createTireDto: CreateTireDto,
-  ): Promise<void> {
-    const res = await validate(createTireDto);
-    if (res.length > 0) {
-      throw new BadRequestException('입력 정보가 잘못되었습니다');
+      throw new BadRequestException(TIRE_ERROR_MSG.INVALID_INPUT_DATA);
     }
   }
 }

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -40,5 +40,8 @@ export class TiresController {
     if (!(body instanceof Array)) {
       throw new BadRequestException(TIRE_ERROR_MSG.INVALID_INPUT_DATA);
     }
+    if (body.length <= 0 || body.length > 5) {
+      throw new BadRequestException(TIRE_ERROR_MSG.INVALID_INPUT_DATA);
+    }
   }
 }

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -20,7 +20,7 @@ export class TiresController {
   async create(
     @Body() body,
   ): Promise<{ createdTireCount: number; result: any }> {
-    this.checkArrayType(body);
+    this.checkArray(body);
 
     const createdTireList = [];
     for (const elem of body) {
@@ -36,7 +36,7 @@ export class TiresController {
     };
   }
 
-  private checkArrayType(body): void {
+  private checkArray(body): void {
     if (!(body instanceof Array)) {
       throw new BadRequestException(TIRE_ERROR_MSG.INVALID_INPUT_DATA);
     }

--- a/src/tires/tires.controller.ts
+++ b/src/tires/tires.controller.ts
@@ -1,8 +1,50 @@
-import { Controller } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { validate } from 'class-validator';
 
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CreateTireDto } from './dto/create-tire.dto';
 import { TiresService } from './tires.service';
 
 @Controller('tires')
 export class TiresController {
   constructor(private readonly tiresService: TiresService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  async create(@Body() body): Promise<{ createdTireCount: number }> {
+    this.checkArrayType(body);
+
+    const createdTireList = [];
+    for (const elem of body) {
+      const createTireDto = new CreateTireDto({ ...elem });
+      await this.validateCreateTireDto(createTireDto);
+
+      createdTireList.push(await this.tiresService.create(createTireDto));
+    }
+
+    return {
+      createdTireCount: createdTireList.length,
+    };
+  }
+
+  private checkArrayType(body): void {
+    if (!(body instanceof Array)) {
+      throw new BadRequestException('입력 정보가 잘못되었습니다');
+    }
+  }
+
+  private async validateCreateTireDto(
+    createTireDto: CreateTireDto,
+  ): Promise<void> {
+    const res = await validate(createTireDto);
+    if (res.length > 0) {
+      throw new BadRequestException('입력 정보가 잘못되었습니다');
+    }
+  }
 }

--- a/src/tires/tires.module.ts
+++ b/src/tires/tires.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { TiresService } from './tires.service';
@@ -6,7 +7,7 @@ import { TiresController } from './tires.controller';
 import { Tire } from './entities/tire.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Tire])],
+  imports: [TypeOrmModule.forFeature([Tire]), HttpModule],
   controllers: [TiresController],
   providers: [TiresService],
 })

--- a/src/tires/tires.module.ts
+++ b/src/tires/tires.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { TiresService } from './tires.service';
+import { TiresController } from './tires.controller';
+import { Tire } from './entities/tire.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tire])],
+  controllers: [TiresController],
+  providers: [TiresService],
+})
+export class TiresModule {}

--- a/src/tires/tires.module.ts
+++ b/src/tires/tires.module.ts
@@ -5,9 +5,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TiresService } from './tires.service';
 import { TiresController } from './tires.controller';
 import { Tire } from './entities/tire.entity';
+import { UsersModule } from '../users/users.module';
+import { OwnCarsModule } from '../own-cars/own-cars.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Tire]), HttpModule],
+  imports: [
+    TypeOrmModule.forFeature([Tire]),
+    HttpModule,
+    UsersModule,
+    OwnCarsModule,
+  ],
   controllers: [TiresController],
   providers: [TiresService],
 })

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TiresService {}

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -1,4 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreateTireDto } from './dto/create-tire.dto';
+import { Tire } from './entities/tire.entity';
 
 @Injectable()
-export class TiresService {}
+export class TiresService {
+  constructor(
+    @InjectRepository(Tire) private tiresRepository: Repository<Tire>,
+  ) {}
+
+  async create(createTireDto: CreateTireDto) {
+    return 'Tire';
+  }
+}

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -1,17 +1,50 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { HttpService } from '@nestjs/axios';
 import { Repository } from 'typeorm';
+import { lastValueFrom, map } from 'rxjs';
 
 import { CreateTireDto } from './dto/create-tire.dto';
 import { Tire } from './entities/tire.entity';
+
+interface Result {
+  status: string;
+  data: any;
+}
 
 @Injectable()
 export class TiresService {
   constructor(
     @InjectRepository(Tire) private tiresRepository: Repository<Tire>,
+    private httpService: HttpService,
   ) {}
 
   async create(createTireDto: CreateTireDto) {
-    return 'Tire';
+    const { trim_id, user_id } = createTireDto;
+    return await this.getTireInfoFromAPI(trim_id);
+  }
+
+  async getTireInfoFromAPI(trim_id: number): Promise<Result> {
+    const url = `https://dev.mycar.cardoc.co.kr/v1/trim/${trim_id}`;
+    const observer = this.httpService
+      .get(url)
+      .pipe(map((axiosResponse) => axiosResponse));
+
+    const getTireInfo = (axiosResponse) => {
+      return {
+        status: 'success',
+        data: {
+          frontTire: axiosResponse.data.spec.driving.frontTire.value,
+          rearTire: axiosResponse.data.spec.driving.rearTire.value,
+        },
+      };
+    };
+
+    const getError = (err) => ({
+      status: 'error',
+      data: { status: err.response.status, data: err.response.data },
+    });
+
+    return await lastValueFrom(observer).then(getTireInfo).catch(getError);
   }
 }

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -6,6 +6,8 @@ import { lastValueFrom, map } from 'rxjs';
 
 import { CreateTireDto } from './dto/create-tire.dto';
 import { Tire } from './entities/tire.entity';
+import { OwnCarsService } from '../own-cars/own-cars.service';
+import { CreateOwnCarDto } from 'src/own-cars/dto/create-own-car.dto';
 
 interface Result {
   status: string;
@@ -17,11 +19,47 @@ export class TiresService {
   constructor(
     @InjectRepository(Tire) private tiresRepository: Repository<Tire>,
     private httpService: HttpService,
+    private ownCarsService: OwnCarsService,
   ) {}
 
   async create(createTireDto: CreateTireDto) {
     const { trim_id, user_id } = createTireDto;
-    return await this.getTireInfoFromAPI(trim_id);
+    const APIresult = await this.getTireInfoFromAPI(trim_id);
+
+    if (APIresult.status === 'success') {
+      const createOwnCarDto = new CreateOwnCarDto();
+      createOwnCarDto.trim_id = trim_id.toString();
+      const createdOwnCar = await this.ownCarsService.create(
+        createOwnCarDto,
+        user_id,
+      );
+
+      const { frontTire, rearTire } = APIresult.data;
+      const [frontTireWidth, frontTireAspectRatio, frontTireWheelSize] =
+        frontTire.split(/[\/R]/g);
+      const [rearTireWidth, rearTireAspectRatio, rearTireWheelSize] =
+        rearTire.split(/[\/R]/g);
+
+      const tire = new Tire();
+      tire.TIRE_FRONT_WIDTH = frontTireWidth;
+      tire.TIRE_FRONT_ASPECT_RATIO = frontTireAspectRatio;
+      tire.TIRE_FRONT_WHEEL_SIZE = frontTireWheelSize;
+      tire.TIRE_REAR_WIDTH = rearTireWidth;
+      tire.TIRE_REAR_ASPECT_RATIO = rearTireAspectRatio;
+      tire.TIRE_REAR_WHEEL_SIZE = rearTireWheelSize;
+      tire.ownCar = createdOwnCar;
+
+      const { ownCar, ...createdTire } = await this.tiresRepository.save(tire);
+
+      return { status: 'success', user_id, trim_id, tire: createdTire };
+    } else if (APIresult.status === 'error') {
+      return {
+        status: 'error',
+        user_id,
+        trim_id,
+        message: APIresult.data.message,
+      };
+    }
   }
 
   async getTireInfoFromAPI(trim_id: number): Promise<Result> {
@@ -31,13 +69,27 @@ export class TiresService {
       .pipe(map((axiosResponse) => axiosResponse));
 
     const getTireInfo = (axiosResponse) => {
+      let frontTire = axiosResponse.data.spec.driving.frontTire.value;
+      let rearTire = axiosResponse.data.spec.driving.rearTire.value;
+
+      frontTire = frontTire.replace(' ', '');
+      rearTire = rearTire.replace(' ', '');
+
+      validateTire(frontTire, 'front');
+      validateTire(rearTire, 'rear');
+
       return {
         status: 'success',
-        data: {
-          frontTire: axiosResponse.data.spec.driving.frontTire.value,
-          rearTire: axiosResponse.data.spec.driving.rearTire.value,
-        },
+        data: { frontTire, rearTire },
       };
+    };
+
+    const validateTire = (tire, tireType) => {
+      if (tire.search(/^[0-9]{3}\/[0-9]{2}R[0-9]{2}/g) === -1) {
+        throw new InternalServerErrorException(
+          `invalid ${tireType} tire format(${tire})`,
+        );
+      }
     };
 
     const getError = (err) => {

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -24,7 +24,7 @@ export class TiresService {
 
     if (APIresult.status === TIRE_CONSTANTS.VALID_TIRE_STATUS) {
       const createOwnCarDto = new CreateOwnCarDto();
-      createOwnCarDto.trim_id = trim_id.toString();
+      createOwnCarDto.trim_id = trim_id;
       const createdOwnCar = await this.ownCarsService.create(
         createOwnCarDto,
         user_id,

--- a/src/tires/tires.service.ts
+++ b/src/tires/tires.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { HttpService } from '@nestjs/axios';
 import { Repository } from 'typeorm';
@@ -40,10 +40,18 @@ export class TiresService {
       };
     };
 
-    const getError = (err) => ({
-      status: 'error',
-      data: { status: err.response.status, data: err.response.data },
-    });
+    const getError = (err) => {
+      if (err instanceof InternalServerErrorException) {
+        return {
+          status: 'error',
+          data: { message: err.message },
+        };
+      }
+      return {
+        status: 'error',
+        data: err.response.data,
+      };
+    };
 
     return await lastValueFrom(observer).then(getTireInfo).catch(getError);
   }


### PR DESCRIPTION
## 개요
타이어 정보 저장 구현

## 세부내용
- 타이어 정보 저장 구현
- 소유 자동차 정보(trimId) own_car 테이블에 저장
- 트랜잭션 처리
- axios를 통해 자동차 정보를 가져와서 타이어 정보 파싱
- 한번에 다수의 타이어 정보 저장 구현

request
<img src="https://user-images.githubusercontent.com/51621520/143423547-48197a01-46f9-4660-91f8-ac5c1964be58.png" width=60% />

response
<img src="https://user-images.githubusercontent.com/51621520/143423633-da66af98-7410-43c8-a6e6-c2e1876c3fed.png" width=60% />


## 관련 이슈
#4, #5